### PR TITLE
Add new method bindObj that uses the $parse service for binding deep scope objects.

### DIFF
--- a/localFactory.js
+++ b/localFactory.js
@@ -1,5 +1,5 @@
 // yourModuleVariable would be something like var yourModuleVariable = angular.module('yourModuleVariable',...
-yourModuleVariable.factory("$store",function(){
+yourModuleVariable.factory("$store",function($parse){
 	/**
 	 * Global Vars
 	 */
@@ -104,7 +104,27 @@ yourModuleVariable.factory("$store",function(){
 				publicMethods.set(key,val);
 			},true);
 			return publicMethods.get(key);
+		},
+		/**
+		 * BindObj - lets you directly bind a localStorage value to a $scope (sub-)object
+		 * @param $scope - the current scope you want the variable available in
+		 * @param key - the accessor string
+		 * @param obj - an Angular expression string denoting the object in $scope you are binding
+		 * @param def - the default value (OPTIONAL)
+		 * @returns {*} - returns whatever the stored value is
+		 */
+		bindObj: function($scope,key,obj,def){
+			def = def || false;
+			if(!publicMethods.get(key)){
+				publicMethods.set(key,def);
+			}
+			$parse(obj).assign($scope, publicMethods.get(key));
+			$scope.$watch(obj,function(val){
+				publicMethods.set(key,val);
+			},true);
+			return publicMethods.get(key);
 		}
+
 	};
 	return publicMethods;
 });


### PR DESCRIPTION
@agrublev: thanks for your great code!

The current `bind` method can bind only values at the top level of the scope.
The new method `bindObj($scope, key, obj, def)` can also bind values in sub-objects of the scope. Third parameter `obj` is an Angular expression for the value to be bound.

Example:

```
$store.bindObj($scope,'viewType','model.view[7].type','cardView');
```

This will bind the value at `$scope.model.view[7].type` to the local storage key `'viewType'`.

Inspired by [this](https://github.com/firebase/angularFire/pull/18) and [this](https://github.com/firebase/angularFire/pull/29).
