### PR TITLE
check if val is defined before overwriting

### DIFF
--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -105,7 +105,9 @@ angular.module('localStorage', ['ngCookies']).factory('$store', function ($parse
 			}
 			$parse(key).assign($scope, publicMethods.get(key));
 			$scope.$watch(key, function (val) {
-				publicMethods.set(key, val);
+				if (angular.isDefined(val)) {
+					publicMethods.set(key, val);
+				}
 			}, true);
 			return publicMethods.get(key);
 		},


### PR DESCRIPTION
When a validation error occured in form, undefined value is stored in localStorage instead of keeping last valid value known
