### PR TITLE
fix : don't use JSON.stringify on primitives

### DIFF
--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -50,7 +50,8 @@ angular.module('localStorage', ['ngCookies']).factory('$store', ['$parse', '$coo
 					$log.log('Local Storage not supported, make sure you have angular-cookies enabled.');
 				}
 			}
-			var saver = $window.JSON.stringify(value);
+			var valueType = Object.prototype.toString.call(value).slice(8, -1);
+			var saver = (valueType === 'String' || valueType === 'Number' || valueType === 'Boolean' || valueType === undefined || valueType === null) ? value : $window.JSON.stringify(value);
 			storage.setItem(key, saver);
 			return privateMethods.parseValue(saver);
 		},

--- a/test/localFactory.spec.js
+++ b/test/localFactory.spec.js
@@ -9,20 +9,44 @@ describe('angular-localStorage module', function () {
 		});
 	});
 
-	describe('when use set() && get() methods', function () {
+        describe('when use set() && get() methods', function () {
 
-		beforeEach(function () {
-			$store.set('spec', 'some test string');
-		});
+                it('should store primitives in localStorage', function () {
+                        $store.set('spec', 'some test string');
+                        expect($store.get('spec')).toEqual('some test string');
 
-		beforeEach(function () {
-			testValue = $store.get('spec');
-		});
+                        $store.set('spec', 1);
+                        expect($store.get('spec')).toEqual(1);
 
-		it('should store value in localStorage', function () {
-			expect(testValue).toBe('some test string');
-		});
-	});
+                        $store.set('spec', 1.5);
+                        expect($store.get('spec')).toEqual(1.5);
+
+                        $store.set('spec', true);
+                        expect($store.get('spec')).toBeTruthy();
+
+                        $store.set('spec', false);
+                        expect($store.get('spec')).toBeFalsy();
+
+                        $store.set('spec', null);
+                        expect($store.get('spec')).toBeNull();
+                });
+
+                it('should store object in localStorage', function () {
+                        $store.set('spec', {});
+                        expect($store.get('spec')).toEqual({});
+
+                        $store.set('spec', {"value": 1});
+                        expect($store.get('spec')).toEqual({"value": 1});
+                });
+
+                it('should store array in localStorage', function () {
+                        $store.set('spec', []);
+                        expect($store.get('spec')).toEqual([]);
+
+                        $store.set('spec', [1,2,3]);
+                        expect($store.get('spec')).toEqual([1,2,3]);
+                });
+        });
 
 	describe('when bind() $scope field to localStorage', function () {
 		beforeEach(function () {


### PR DESCRIPTION
When a string is stored, quote are added around in localStorage cause we use JSON.stringify on it, so when you try to get value without using this library you get wrong stuff.
I had to rewrite get/set part cause I was enabled to test everything properly but it breaks the way you designed tests... I couldn't add a test for undefined value cause it returns me an undefined string not undefined value, I have to see where it comes from but it was not from my modifications, I started tests before doing any modifications.
