### PR TITLE
Added additional checks to make sure localStorage is really supported

### DIFF
--- a/src/angularLocalStorage.js
+++ b/src/angularLocalStorage.js
@@ -5,6 +5,21 @@ angular.module('angularLocalStorage', ['ngCookies']).factory('storage', ['$parse
 	var storage = (typeof $window.localStorage === 'undefined') ? undefined : $window.localStorage;
 	var supported = !(typeof storage === 'undefined');
 
+	if (supported) {
+		// When Safari (OS X or iOS) is in private browsing mode it appears as though localStorage
+		// is available, but trying to call .setItem throws an exception below:
+		// "QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota."
+		var testKey = '__' + Math.round(Math.random() * 1e7);
+
+		try {
+			localStorage.setItem(testKey, testKey);
+			localStorage.removeItem(testKey);
+		}
+		catch (err) {
+			supported = false;
+		}
+	}
+
 	var privateMethods = {
 		/**
 		 * Pass any type of a string from the localStorage to be parsed so it returns a usable version (like an Object)


### PR DESCRIPTION
Fixes private browsing QUOTA_EXCEEDED_ERR issue in Safari.

Currently Safari (in OSX or iOS) will throw an exception if you try to call the setItem method while in Private Browsing mode.