### PR TITLE
Fixed confusing use of invert boolean

### DIFF
--- a/src/angularLocalStorage.js
+++ b/src/angularLocalStorage.js
@@ -3,7 +3,7 @@ angular.module('angularLocalStorage', ['ngCookies']).factory('storage', ['$parse
 	 * Global Vars
 	 */
 	var storage = (typeof $window.localStorage === 'undefined') ? undefined : $window.localStorage;
-	var supported = !(typeof storage === 'undefined');
+	var supported = typeof storage !== 'undefined';
 
 	var privateMethods = {
 		/**


### PR DESCRIPTION
This line was bugging me slightly, firstly it may be a typo from something that was regressed, and secondly JSHint didn't like it:

```
[L6:C21] W018: Confusing use of '!'.
    var supported = !(typeof storage === 'undefined');
```

This fixes any breaks if running the source through JSHint, and removes unnecessary wrapping of that operator.
