### PR TITLE
Add localStorage & sessionStorage factories

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -21,11 +21,11 @@
     <script>
         var eS = angular.module('exampleStore', ['angularLocalStorage']);
 
-        eS.controller('MainCtrl', ['$scope', 'storage', function ( $scope, storage ) {
-            storage.bind($scope, 'test', 'Some Default Text');
+        eS.controller('MainCtrl', ['$scope', 'localStorage', function ( $scope, localStorage ) {
+            localStorage.bind($scope, 'test', 'Some Default Text');
 
             $scope.clearTest = function () {
-                storage.remove('test');
+                localStorage.remove('test');
             };
         }]);
     </script>
@@ -54,11 +54,11 @@
                 <pre>
 var eS = angular.module('exampleStore', ['angularLocalStorage']);
 
-eS.controller('MainCtrl', ['$scope', 'storage', function ( $scope, storage ) {
-    storage.bind($scope, 'test', 'Some Default Text');
+eS.controller('MainCtrl', ['$scope', 'localStorage', function ( $scope, localStorage ) {
+    localStorage.bind($scope, 'test', 'Some Default Text');
 
     $scope.clearTest = function () {
-        storage.remove('test');
+        localStorage.remove('test');
     };
 }]);
                 </pre>

--- a/test/angularLocalStorage.spec.js
+++ b/test/angularLocalStorage.spec.js
@@ -5,7 +5,8 @@ describe('angularLocalStorage module', function () {
 		module('angularLocalStorage');
 
 		inject(function ($injector) {
-			storage = $injector.get('storage');
+			storage = $injector.get('localStorage');
+			sessionStorage = $injector.get('sessionStorage');
 		});
 	});
 
@@ -17,6 +18,21 @@ describe('angularLocalStorage module', function () {
 
 		beforeEach(function () {
 			testValue = storage.get('spec');
+		});
+
+		it('should store value in localStorage', function () {
+			expect(testValue).toBe('some test string');
+		});
+	});
+
+	describe('when use set() && get() methods (sessionStorage version)', function () {
+
+		beforeEach(function () {
+			sessionStorage.set('spec', 'some test string');
+		});
+
+		beforeEach(function () {
+			testValue = sessionStorage.get('spec');
 		});
 
 		it('should store value in localStorage', function () {


### PR DESCRIPTION
I needed to do the same as angularLocalStorage but using sessionStorage.
I thought that instead of creating a new library, I could patch this one to provide the same possibilities but using sessionStorage :)

SessionStorage is the same as localStorage, an object inheriting Storage (see https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Storage), but with limited persistence (as long as the tab remains opened in the browser).

This PR provides 3 factories instead of one:
- storage
- localStorage
- sessionStorage

The storage service now needs as first argument of each of its methods the storage provider to use ($window.localStorage for example). localStorage and sessionStorage providers are shortcuts that provide the right parameter.

The localStorage service uses $window.localStorage and $cookieStore as a fallback as before.
The sessionStorage service uses only the $window.sessionStorage if available.

I am aware that this PR would break the current API (meaning you would have to inject "localStorage" instead of "storage").
However, I believe that this would be the right way to go in order to handle any kind of storage provider easily and elegantly.
