### PR TITLE
Fix store when a value already exists in scope

### DIFF
--- a/src/angularLocalStorage.js
+++ b/src/angularLocalStorage.js
@@ -127,11 +127,12 @@
 
 				// If a value doesn't already exist store it as is
 				if (!publicMethods.get(storeName)) {
-					publicMethods.set(storeName, opts.defaultValue);
+					publicMethods.set(storeName, $parse(key)($scope) || opts.defaultValue);
 				}
 
 				// If it does exist assign it to the $scope value
-				$parse(key).assign($scope, publicMethods.get(storeName));
+				else
+					$parse(key).assign($scope, publicMethods.get(storeName));
 
 				// Register a listener for changes on the $scope value
 				// to update the localStorage value


### PR DESCRIPTION
If the value already exists in the scope when you bind the variable, the library overwrittes it by the default value (often : "").
