### PR TITLE
Updated the version in bower.json to reflect the 0.3.0 release. Updated ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ or
 bower install git://github.com/agrublev/angularLocalStorage.git
 ```
 
+## Angular Requirements
+0.3.0 requires AngularJS 1.3.0+.
+
+0.2.0 requires AngularJS 1.2.x.
+
 ## Example
 
 For live example please checkout - http://plnkr.co/edit/Y1mrNVRkInCItqvZXtto?p=preview
@@ -72,5 +77,5 @@ Please add an issue with ideas, improvements, or bugs! Thanks!
 
 ---
 
-(c) 2013 MIT License
+(c) 2015 MIT License
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angularLocalStorage",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/angularLocalStorage.js",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Sets the correct version in the bower.json file so a maintainer could release this version officially to Bower.

I also updated the README so it's clear that version 0.2.0 relies on AngularJS 1.2.x, and 0.3.0 will require AngularJS ~1.3.0.