### PR TITLE
#44 - Updated docs to show what an undefined key will return in storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The simpliest localStorage module you will ever use. Allowing you to set, get, a
   storage.set('key','value');
   // getting that value
   storage.get('key');
+
+  // Getting an unset key will return null
+  console.log(storage.get('keyThatIsUndefined')) // null
   
   // checking if the cookie fallback is being used right now, so you don't try to store fairly big data in cookies
   if(!storage.isCookieFallbackActive()) {

--- a/test/angularLocalStorage.spec.js
+++ b/test/angularLocalStorage.spec.js
@@ -24,6 +24,10 @@ describe('angularLocalStorage module', function () {
     it('should store value in localStorage', function () {
       expect(testValue).toBe('some test string');
     });
+
+    it('should return null when unset key is used', function () {
+      expect(storage.get('madeUpKey')).toBeNull();
+    });
   });
 
   describe('when bind() $scope field to localStorage', function () {


### PR DESCRIPTION
#44 - Added a return type to the docs for when ```storage.get('invalidKey')``` is called. Updated the Unit Test to cover that scenario as well in the getter/setter tests.